### PR TITLE
fix(backend) docker image not building for missing input

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /backend
 
 COPY requirements.txt .
 
-RUN apt-get update && \
-    apt-get upgrade && \
+RUN apt-get update -y && \
+    apt-get upgrade -y && \
     apt-get install -y gcc libpq-dev cargo
 
 RUN pip install --no-cache-dir --upgrade -r requirements.txt


### PR DESCRIPTION
Docker backend image wasn't able to build becasue it didn't get the confirmation when apt was asking to update