### PR TITLE
feat: refine login process

### DIFF
--- a/backend/auth/services.py
+++ b/backend/auth/services.py
@@ -11,9 +11,18 @@ from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from jwt.exceptions import InvalidTokenError
 from passlib.context import CryptContext
+from sqlalchemy.orm import Session
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+__all__ = [
+    "verify_password",
+    "get_password_hash",
+    "get_user",
+    "get_user_by_token",
+    "is_token_linked_to_correct_user",
+]
 
 
 def verify_password(plain_password, hashed_password):
@@ -40,13 +49,12 @@ def get_user(email: str):
         )
 
 
-def authenticate_user(email: str, password: str):
-    user = get_user(email=email)
+def authenticate_user(email: str, password: str, db: Session):
+    user = db.query(User).filter(User.email == email).first()
     if not user:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
         )
-
     # `user.password` is the hashed password stored in the db
     # `hashed_password_from_form` is the hashed password from the form
     # if they are not equal, the password is wrong
@@ -69,7 +77,7 @@ def create_access_token(
     return TokenData(token=encoded_jwt, expire_at=expire)
 
 
-async def get_user_by_token(token: str):
+def get_user_by_token(token: str):
     db = next(get_db())
     user = db.query(User).filter_by(token=token).first()
     if not user:
@@ -78,6 +86,13 @@ async def get_user_by_token(token: str):
             detail="Invalid token. Please login again.",
         )
     return user
+
+
+def is_token_linked_to_correct_user(token: str, email: str) -> bool:
+    user = get_user_by_token(token=token)
+    if user.email != email:
+        return False
+    return True
 
 
 # reminder: is this function used? Could it be simplified

--- a/backend/core/middleware.py
+++ b/backend/core/middleware.py
@@ -1,9 +1,13 @@
 from fastapi import Request
 from fastapi.responses import JSONResponse
-from auth.services import get_user_by_token
+from auth.services import is_token_linked_to_correct_user, get_user_by_token
 from fastapi import status
 
-__all__ = ["create_login_middleware", "ORIGINS"]
+__all__ = [
+    "create_already_authenticated_middleware",
+    "create_login_middleware",
+    "ORIGINS",
+]
 
 ORIGINS = [
     # TODO: remove localhost when "production"
@@ -30,7 +34,6 @@ def create_login_middleware():
             # Get the Authorization header. Accessing the header as a dictionary
             # to handle the case where the header is not present with a KeyError.
             # This is a more Pythonic way to handle this situation.
-
             auth_header = request.headers["Authorization"]
 
             # Check if it starts with "Token "
@@ -58,3 +61,51 @@ def create_login_middleware():
             )
 
     return login_required
+
+
+def create_already_authenticated_middleware():
+    async def already_authenticated(request: Request, call_next):
+        checked_path: list[str] = ["/login", "/register"]
+
+        if request.url.path not in checked_path:
+            return await call_next(request)
+
+        if (
+            request.url.path in checked_path
+            and request.headers.get("Authorization") is None
+        ):
+            return await call_next(request)
+
+        try:
+            # Check if user is already authenticated via token
+            auth_header = request.headers["Authorization"]
+            token = auth_header.removeprefix("Token ")
+            user = get_user_by_token(token=token)
+            if not is_token_linked_to_correct_user(token=token, email=user.email):
+                return JSONResponse(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    content={
+                        "detail": "Unauthorized: Token is not linked to the correct user"
+                    },
+                )
+            if user.is_active:
+                return JSONResponse(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    content={
+                        "detail": "You are already authenticated. Please logout first."
+                    },
+                )
+        except KeyError:
+            return JSONResponse(
+                status_code=status.HTTP_403_FORBIDDEN,
+                content={"detail": "Unauthorized: No token found"},
+            )
+        except Exception:
+            return JSONResponse(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                content={"detail": "A critical error occurred"},
+            )
+
+        return await call_next(request)
+
+    return already_authenticated

--- a/frontend/incassi/angular.json
+++ b/frontend/incassi/angular.json
@@ -29,10 +29,7 @@
                 "input": "public"
               }
             ],
-            "styles": [
-              "@angular/material/prebuilt-themes/cyan-orange.css",
-              "src/styles.scss"
-            ],
+            "styles": ["@angular/material/prebuilt-themes/cyan-orange.css", "src/styles.scss"],
             "scripts": []
           },
           "configurations": {
@@ -88,14 +85,14 @@
                 "input": "public"
               }
             ],
-            "styles": [
-              "@angular/material/prebuilt-themes/cyan-orange.css",
-              "src/styles.scss"
-            ],
+            "styles": ["@angular/material/prebuilt-themes/cyan-orange.css", "src/styles.scss"],
             "scripts": []
           }
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/frontend/incassi/biome.json
+++ b/frontend/incassi/biome.json
@@ -14,12 +14,16 @@
       "dist",
       "src/assets/**",
       "tsconfig.*",
-      "karma.conf.js"
+      "karma.conf.js",
+      ".angular/",
+      "node_modules/",
+      "src/environments/"
     ]
   },
   "formatter": {
     "enabled": true,
-    "indentStyle": "space"
+    "indentStyle": "space",
+    "lineWidth": 120
   },
   "organizeImports": {
     "enabled": true

--- a/frontend/incassi/src/app/app.config.ts
+++ b/frontend/incassi/src/app/app.config.ts
@@ -1,9 +1,15 @@
 import {type ApplicationConfig, provideZoneChangeDetection} from '@angular/core'
 import {provideRouter} from '@angular/router'
 
+import {provideHttpClient} from '@angular/common/http'
 import {provideAnimationsAsync} from '@angular/platform-browser/animations/async'
 import {routes} from './app.routes'
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideZoneChangeDetection({eventCoalescing: true}), provideRouter(routes), provideAnimationsAsync()],
+  providers: [
+    provideZoneChangeDetection({eventCoalescing: true}),
+    provideRouter(routes),
+    provideAnimationsAsync(),
+    provideHttpClient(),
+  ],
 }

--- a/frontend/incassi/src/app/services/auth/Models.ts
+++ b/frontend/incassi/src/app/services/auth/Models.ts
@@ -1,0 +1,4 @@
+export interface LoginResponse {
+  message: string
+  token: string
+}

--- a/frontend/incassi/src/app/services/auth/auth.service.spec.ts
+++ b/frontend/incassi/src/app/services/auth/auth.service.spec.ts
@@ -1,0 +1,16 @@
+import {TestBed} from '@angular/core/testing'
+
+import {AuthService} from './auth.service'
+
+describe('AuthService', () => {
+  let service: AuthService
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({})
+    service = TestBed.inject(AuthService)
+  })
+
+  it('should be created', () => {
+    expect(service).toBeTruthy()
+  })
+})

--- a/frontend/incassi/src/app/services/auth/auth.service.ts
+++ b/frontend/incassi/src/app/services/auth/auth.service.ts
@@ -1,0 +1,22 @@
+import {HttpClient, HttpHeaders} from '@angular/common/http'
+import {Injectable, inject} from '@angular/core'
+import type {Observable} from 'rxjs'
+import type {LoginResponse} from './Models'
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AuthService {
+  private readonly http: HttpClient = inject(HttpClient)
+  private readonly API_URL: string = 'http://localhost:8000'
+  private readonly httpOptions: HttpHeaders = new HttpHeaders({
+    'Content-Type': 'application/x-www-form-urlencoded',
+  })
+
+  login(email: string, password: string): Observable<LoginResponse> {
+    return this.http.post<LoginResponse>(`${this.API_URL}/login`, `email=${email}&password=${password}`, {
+      headers: this.httpOptions,
+      withCredentials: true,
+    })
+  }
+}


### PR DESCRIPTION
- Added new service to call the `/login` endpoint, with some basic
  error handling
- Refined some styling options
- Added a way to find out if the user is already logged in based on the
  `is_active` bool field in db and the request header.
- Check if the token provided is linked to an existing user